### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To get started checkout http://rickardn.github.io/listgroup.js/
 ## Quick start
 
 - [Download the latest release](https://github.com/rickardn/listgroup.js/zipball/master)
-- or [reference CDN version](https://cdn.jsdelivr.net/bootstrap.listgroup/1.1.2/listgroup.min.js)
+- or [reference CDN version](https://cdn.jsdelivr.net/gh/rickardn/listgroup.js@1.1.2/listgroup.min.js)
 - Reference the `listgroup.js` or `listgroup.min.js` in your HTML document after jQuery
 - Done!
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/rickardn/listgroup.js.

Feel free to ping me if you have any questions regarding this change.